### PR TITLE
Make the licence more general to easy the adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ You have the right to use, free of charge, the Software and its derivates for pe
 
 ## Change of licence
 
-In the event that no new official binary releases of the software are published by *\<copyright holders\>* for three consecutive years, the above conditions are permanently waived, and the software is additionally made available under the terms of the MIT license.
+In the event that no new official binary releases of the software are published by *\<copyright holders\>* for two consecutive years, the above conditions are permanently waived, and the software is additionally made available under the terms of the MIT license.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,30 +6,33 @@ This license is used to distribute LiveReload apps, and you're encouraged to ado
 
 Note that this license is not suitable for reusable libraries; it is meant for end-user apps.
 
-
 ## License Text
 
-Copyright 2012 Andrey Tarantsov — andrey@tarantsov.com
+-----
 
-**Purchasing policy notice:** All users of the software are expected to purchase a license from Andrey Tarantsov unless they have a good reason not to pay. Users that don't purchase a license are encouraged to apply for a free one at support@livereload.com. The users are free to:
+# Open Community Indie Software License
+Copyright (c) \<YEAR\> \<copyright holders\>
 
-* download, build and modify the app;
-* share the modified source code;
-* share the purchased or custom-built binaries (with unmodified license and contact info), provided that the purchasing policy is explained to all potential users.
+Permission is hereby granted, free of charge, to copy, modify, merge and/or distribute the software and associated documentation files (the "Software") for any purpose, subject to the following conditions:
 
+## General
 
-This software is available under the **Open Community Indie Software License**:
+* All users of the software are expected to purchase a use license from *\<copyright holders\>*. Users may apply for a free license at *\<contact email\>*.
 
-Permission to use, copy, modify, and/or distribute this software for any purpose is hereby granted, free of charge, subject to the following conditions:
+* All copies retain the above copyright notice, the above purchasing notice and this permission notice unmodified.
 
-* all copies retain the above copyright notice, the above purchasing policy notice and this permission notice unmodified;
+* All copies retain the name of the software (\<name\>), the name of the author (\<copyright holders\>) and the contact information (including, but not limited to, the *\<contact email\>* and *\<website URL\>*) unmodified.
 
-* all copies retain the name of the software (LiveReload), the name of the author (Andrey Tarantsov) and the contact information (including, but not limited to, pointers to support@livereload.com and livereload.com URLs) unmodified;
+* No fee is charged for distibution of the software.
 
-* no fee is charged for distibution of the software;
+* The best effort is made to explain the purchasing policy to all users of the software.
 
-* the best effort is made to explain the purchasing policy to all users of the software.
+## Personal use
 
-In the event that no new official binary releases of the software are published for two consecutive years, the above conditions are permanently waived, and the software is additionally made available under the terms of the MIT license.
+You have the right to use, free of charge, the Software and its derivates for personal use if you have a good reason not to pay the use license mentioned in the purchasing notice.
+
+## Change of licence
+
+In the event that no new official binary releases of the software are published by *\<copyright holders\>* for three consecutive years, the above conditions are permanently waived, and the software is additionally made available under the terms of the MIT license.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
The licence have a new format for people to fill in their information. Also there is a change to reduce the free of charge use permission to personal use. This makes more clear that all "freedom" rights are granted but the use needs a licence, which can be a free one if the owner is contacted or the software is used for personal use.

In this case personal use doesn't involve a "no monetary" license clause. This personal use involves a use of the software where only one person is using it, not a whole organization. This is ambiguous in the sense that inside a organization only one person uses at a time, and every use can be justified as "personal use", but if the software is used inside a organization as part of their technologic stack this use case would not be a good reason to not pay a use licence.
